### PR TITLE
fix autoprof_discover.yml and extract_result.py

### DIFF
--- a/.github/workflows/autoprof_discover.yml
+++ b/.github/workflows/autoprof_discover.yml
@@ -29,7 +29,7 @@ jobs:
           OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
         run: |
           set -x
-          upload_day_ago=${upload_day_ago:-0}
+          upload_day_ago=${upload_day_ago:-1}
           branch_name=${branch_name:-"master"}
           upload_issue_date=$(date -d "${upload_day_ago} day ago" +%Y%m%d)
           curl http://gosspublic.alicdn.com/ossutil/1.6.19/ossutil64 -o $HOME/ossutil64

--- a/onebench/libai/extract_result.py
+++ b/onebench/libai/extract_result.py
@@ -146,7 +146,7 @@ def extract_result(args, extract_func):
     nvidia_name = ""
     for commit in commit_list:
         
-        logs_list = glob.glob(os.path.join(args.test_logs, "{}/*/*/output.log".format(commit)))
+        logs_list = glob.glob(os.path.join(args.test_logs, "{}/*/output.log".format(commit)))
         logs_list = sorted(logs_list)
 
         for log in logs_list:

--- a/onebench/models/ResNet50/extract_result.py
+++ b/onebench/models/ResNet50/extract_result.py
@@ -82,7 +82,7 @@ def extract_info_from_file(log_file):
     with open(log_file, "r") as f:
         for line in f.readlines():
             ss = line.lstrip().split(" ")
-            if "MiB," in line and "utilization" not in line and len(ss) == 18:
+            if "MiB," in line and "utilization" not in line and len(ss) == 17:
 
                 memory_userd = int(ss[-2])
                 if (


### PR DESCRIPTION
- 将autoprof_discover.yml的up_load_day_ago变量的默认值由0修改为1。
- 因为显卡名字从3080_ti变成3090，所以resnet的extract_result.py的第85行修改为len(ss)=17。
- 因为output.log保存的位置在commit/case_name/output.log，libai_week的extract_result.py的149行改成"{}/*/output.log".format(commit)。